### PR TITLE
[Timezone] Make time user work in all servers + some fixes

### DIFF
--- a/timezone/timezone.py
+++ b/timezone/timezone.py
@@ -36,7 +36,6 @@ class Timezone(commands.Cog):
                 fmt = "**%H:%M** %d-%B-%Y"
                 await ctx.send(f"Current system time: {time.strftime(fmt)}")
             else:
-                fmt = "**%H:%M** %d-%B-%Y **%Z (UTC %z)**"
                 if "'" in tz:
                     tz = tz.replace("'", "")
                 if len(tz) > 4 and "/" not in tz:
@@ -46,7 +45,8 @@ class Timezone(commands.Cog):
                         "<https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
                     )
                 else:
-                    time = datetime.now(pytz.timezone(tz))
+                    fmt = "**%H:%M** %d-%B-%Y **%Z (UTC %z)**"
+                    time = datetime.now(pytz.timezone(tz.title()))
                     await ctx.send(time.strftime(fmt))
         except Exception as e:
             await ctx.send(f"**Error:** {str(e)} is an unsupported timezone.")

--- a/timezone/timezone.py
+++ b/timezone/timezone.py
@@ -1,43 +1,37 @@
-import aiohttp
 import discord
-import os
 import pytz
 from datetime import datetime
 from pytz import all_timezones
 from pytz import country_timezones
+from typing import Optional
 from redbot.core import Config, commands, checks
 
 
-BaseCog = getattr(commands, "Cog", object)
-
-class Timezone(BaseCog):
+class Timezone(commands.Cog):
     """Gets times across the world..."""
 
     def __init__(self, bot):
         self.bot = bot
         self.config = Config.get_conf(self, 278049241001, force_registration=True)
-
-        default_member = {"usertime": None}
-
-        self.config.register_member(**default_member)
-        self.session = aiohttp.ClientSession()
-
-    def __unload(self):
-        self.session.detach()
+        default_user = {"usertime": None}
+        self.config.register_user(**default_user)
 
     @commands.guild_only()
     @commands.group()
     async def time(self, ctx):
-        """Checks the time.
+        """
+            Checks the time.
 
-        For the list of supported timezones, see here: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"""
+            For the list of supported timezones, see here:
+            https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+        """
         pass
 
     @time.command()
-    async def tz(self, ctx, *, tz):
+    async def tz(self, ctx, *, tz: Optional[str] = None):
         """Gets the time in any timezone."""
         try:
-            if tz == "":
+            if tz is None:
                 time = datetime.now()
                 fmt = "**%H:%M** %d-%B-%Y"
                 await ctx.send(f"Current system time: {time.strftime(fmt)}")
@@ -47,7 +41,9 @@ class Timezone(BaseCog):
                     tz = tz.replace("'", "")
                 if len(tz) > 4 and "/" not in tz:
                     await ctx.send(
-                        "Error: Incorrect format. Use:\n **Continent/City** with correct capitals. e.g. `America/New_York`\n See the full list of supported timezones here:\n <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
+                        "Error: Incorrect format. Use:\n **Continent/City** with correct capitals. "
+                        "e.g. `America/New_York`\n See the full list of supported timezones here:\n "
+                        "<https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
                     )
                 else:
                     time = datetime.now(pytz.timezone(tz))
@@ -56,81 +52,76 @@ class Timezone(BaseCog):
             await ctx.send(f"**Error:** {str(e)} is an unsupported timezone.")
 
     @time.command()
-    async def iso(self, ctx, *, code):
+    async def iso(self, ctx, *, code=None):
         """Looks up ISO3166 country codes and gives you a supported timezone."""
-        if code == "":
+        if code is None:
             await ctx.send("That doesn't look like a country code!")
         else:
-            if code in country_timezones:
-                exist = True
-            else:
-                exist = False
-            if exist == True:
-                msg = f"Supported timezones for **{code}:**\n"
+            exist = True if code in country_timezones else False
+            if exist is True:
                 tz = str(country_timezones(code))
-                tz = tz[:-1]
-                tz = tz[1:]
-                msg += tz
-                msg += f"\n**Use** `[p]time tz Continent/City` **to display the current time in that timezone.**"
+                msg = (
+                    f"Supported timezones for **{code}:**\n{tz[:-1][1:]}"
+                    f"\n**Use** `[p]time tz Continent/City` **to display the current time in that timezone.**"
+                )
                 await ctx.send(msg)
             else:
                 await ctx.send(
-                    "That code isn't supported. For a full list, see here: <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
+                    "That code isn't supported. For a full list, see here: "
+                    "<https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
                 )
 
     @time.command()
-    async def me(self, ctx, *tz):
-        """Sets your timezone.
-        Usage: [p]time me Continent/City"""
-        tz = " ".join(tz)
-        if tz in all_timezones:
-            exist = True
-        else:
-            exist = False
-        usertime = await self.config.member(ctx.message.author).usertime()
-        if tz == "":
+    async def me(self, ctx, *, tz=None):
+        """
+            Sets your timezone.
+            Usage: [p]time me Continent/City
+        """
+        if tz is None:
+            usertime = await self.config.user(ctx.message.author).usertime()
             if not usertime:
                 await ctx.send(
-                    "You haven't set your timezone. Do `[p]time me Continent/City`: see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
+                    "You haven't set your timezone. Do `[p]time me Continent/City`: "
+                    "see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
                 )
             else:
-                msg = f"Your current timezone is **{usertime}.**\n"
                 time = datetime.now(pytz.timezone(usertime))
                 time = time.strftime("**%H:%M** %d-%B-%Y **%Z (UTC %z)**")
-                msg += f"The current time is: {time}"
+                msg = f"Your current timezone is **{usertime}.**\n" f"The current time is: {time}"
                 await ctx.send(msg)
-        elif exist == True:
-            if "'" in tz:
-                tz = tz.replace("'", "")
-            await self.config.member(ctx.message.author).usertime.set(tz)
-            await ctx.send(f"Successfully set your timezone to **{tz}**.")
         else:
-            await ctx.send(
-                "**Error:** Unrecognized timezone. Try `[p]time me Continent/City`: see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
-            )
+            exist = True if tz.title() in all_timezones else False
+            if exist:
+                if "'" in tz:
+                    tz = tz.replace("'", "")
+                await self.config.user(ctx.message.author).usertime.set(tz.title())
+                await ctx.send(f"Successfully set your timezone to **{tz.title()}**.")
+            else:
+                await ctx.send(
+                    "**Error:** Unrecognized timezone. Try `[p]time me Continent/City`: "
+                    "see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
+                )
 
     @time.command()
     @checks.admin_or_permissions(manage_guild=True)
-    async def set(self, ctx, user: discord.Member, *, tz):
+    async def set(self, ctx, user: discord.Member, *, tz=None):
         """Allows the mods to edit timezones."""
-        author = ctx.message.author
         if not user:
-            user = author
-
+            user = ctx.message.author
         if tz is None:
             await ctx.send("That timezone is invalid.")
             return
         else:
-            space = " "
-            timezone = tz.split(space, 1)[0]
-            if timezone in all_timezones:
+            exist = True if tz.title() in all_timezones else False
+            if exist:
                 if "'" in tz:
-                    timezone = timezone.replace("'", "")
-                await self.config.member(user).usertime.set(timezone)
-                await ctx.send(f"Successfully set {user.name}'s timezone.")
+                    tz = tz.replace("'", "")
+                await self.config.user(user).usertime.set(tz.title())
+                await ctx.send(f"Successfully set {user.name}'s timezone to **{tz.title()}**.")
             else:
                 await ctx.send(
-                    "**Error:** Unrecognized timezone. Try `[p]time set @user Continent/City`: see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
+                    "**Error:** Unrecognized timezone. Try `[p]time set @user Continent/City`: "
+                    "see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
                 )
 
     @time.command()
@@ -139,11 +130,14 @@ class Timezone(BaseCog):
         if not user:
             await ctx.send("That isn't a user!")
         else:
-            usertime = await self.config.member(user).usertime()
+            usertime = await self.config.user(user).usertime()
             if usertime:
                 time = datetime.now(pytz.timezone(usertime))
                 fmt = "**%H:%M** %d-%B-%Y **%Z (UTC %z)**"
                 time = time.strftime(fmt)
-                await ctx.send(f"{user.name}'s current time is: {str(time)}")
+                await ctx.send(
+                    f"{user.name}'s current timezone is: **{usertime}**\n"
+                    f"They current time is: {str(time)}"
+                )
             else:
                 await ctx.send("That user hasn't set their timezone.")


### PR DESCRIPTION
As you already know, I love this cog, and as you also know, I've said I'll work on it, so here is the result.
Feel free to let me know if something can be improved, but I think it's good.

- Use `config.register_user` to make it works everywhere and not only in the guild where time me command has been used.
- Before, using `[p]time tz` command without tz was just sending help of the command, and what was intended was send the current system time, it's now fixed.
- `[p]time me` and `[p]time tz` works now without capitalization.
- Add of the timezone set when using `[p]time set` command.
- Add of the current timezone in `[p]time user` command.
- Some code cleanup.