### PR TITLE
Fix handling of negative numbers for trick or treat

### DIFF
--- a/trickortreat/trickortreat.py
+++ b/trickortreat/trickortreat.py
@@ -38,8 +38,10 @@ class TrickOrTreat(commands.Cog):
         pick = await self.config.guild(ctx.guild).pick()
         if not candy_type:
             candy_type = "candies"
-        if number <= 0:
-            number == 1
+        if number < 0:
+            return await ctx.send("That doesn't sound fun.")
+        if number == 0:
+            return await ctx.send("You pretend to eat a candy.")
         if candy_type in ["candies", "candy"]:
             candy_type = "candies"
         if candy_type in ["lollipops", "lollipop"]:


### PR DESCRIPTION
Fixes eating negative candy. Currently eating negative candy will cause your position on the leader board to decrease (and probably your candy balance to increase). 
This instead prints a message suggesting that that is not a good idea.....