### PR TITLE
[TrickOrTreat] Add eaten candies in eat command + changes in cboard

### DIFF
--- a/trickortreat/trickortreat.py
+++ b/trickortreat/trickortreat.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import discord
 import random
+import math
 from redbot.core import commands, checks, Config, bank
 from redbot.core.utils.chat_formatting import box, pagify
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
@@ -128,7 +129,7 @@ class TrickOrTreat(commands.Cog):
                 )
 
             pluralcandy = "candy" if number == 1 else "candies"
-            await ctx.send(f"{random.choice(eat_phrase)} {number} {pluralcandy}.")
+            await ctx.send(f"{random.choice(eat_phrase)} {number} {pluralcandy}. (Total eaten: `{await self.config.user(ctx.author).eaten() + number:,}` \N{CANDY})")
             await self.config.user(ctx.author).sickness.set(userdata["sickness"] + (number * 2))
             await self.config.user(ctx.author).candies.set(userdata["candies"] - number)
             await self.config.user(ctx.author).eaten.set(userdata["eaten"] + number)
@@ -192,7 +193,10 @@ class TrickOrTreat(commands.Cog):
             if account[1]["eaten"] == 0:
                 continue
             user_idx = i + 1
-            user_obj = await self.bot.fetch_user(account[0])
+            try:
+                user_obj = ctx.guild.get_member(account[0])
+            except AttributeError:
+                user_obj = await self.bot.get_user_info(account[0])
             user_name = f"{user_obj.name}#{user_obj.discriminator}"
             if len(user_name) > 28:
                 user_name = f"{user_obj.name[:19]}...#{user_obj.discriminator}"
@@ -203,12 +207,18 @@ class TrickOrTreat(commands.Cog):
             msg += f"{name:33}{account[1]['eaten']}\N{CANDY}\n"
 
         page_list = []
+        pages = 1
         for page in pagify(msg, delims=["\n"], page_length=1000):
             embed = discord.Embed(
-                colour=await ctx.embed_colour(), description=(box(page, lang="md"))
+                colour=await ctx.embed_colour(),
+                description=box(
+                    f"\N{CANDY} Global Leaderboard \N{CANDY}", lang="prolog"
+                )
+                + (box(page, lang="md")),
             )
+            embed.set_footer(text=f"Page {pages:,}/{math.ceil(len(msg) / 1500):,}")
+            pages += 1
             page_list.append(embed)
-        await message.edit(content=box(f"\N{CANDY} Global Leaderboard \N{CANDY}", lang="prolog"))
         await menu(ctx, page_list, DEFAULT_CONTROLS)
 
     @commands.guild_only()

--- a/trickortreat/trickortreat.py
+++ b/trickortreat/trickortreat.py
@@ -181,6 +181,7 @@ class TrickOrTreat(commands.Cog):
 
     @commands.guild_only()
     @commands.command()
+    @commands.bot_has_permissions(embed_links=True, add_reactions=True)
     async def cboard(self, ctx):
         """Show the candy eating leaderboard."""
         userinfo = await self.config._all_from_scope(scope="USER")

--- a/trickortreat/trickortreat.py
+++ b/trickortreat/trickortreat.py
@@ -196,7 +196,7 @@ class TrickOrTreat(commands.Cog):
             try:
                 user_obj = ctx.guild.get_member(account[0])
             except AttributeError:
-                user_obj = await self.bot.get_user_info(account[0])
+                user_obj = await self.bot.fetch_user(account[0])
             user_name = f"{user_obj.name}#{user_obj.discriminator}"
             if len(user_name) > 28:
                 user_name = f"{user_obj.name[:19]}...#{user_obj.discriminator}"


### PR DESCRIPTION
This PR change:
##### `[p]eat` command
- Add total eaten candies at the end of the message.
##### `[p]cboard` command
- Fetch guild members instead of the whole bot. If it fails it will try to fetch user info from the bot.
- Move header directly to the top of the embed and also remove the "Populating leaderboard..." message.
- Add page numbers in footer of the embed.
- Fix required permissions for the bot.