### PR TITLE
pressf reaction now shows username

### DIFF
--- a/pressf/pressf.py
+++ b/pressf/pressf.py
@@ -57,5 +57,5 @@ class PressF(commands.Cog):
             return
         if user.id not in self.channels[str(reaction.message.channel.id)]['reacted']:
             if str(reaction.emoji) == "\U0001f1eb":
-                await reaction.message.channel.send(f"**{user.display_name}** has paid their respects.")
+                await reaction.message.channel.send(f"**{user.name}** has paid their respects.")
                 self.channels[str(reaction.message.channel.id)]['reacted'].append(user.id)


### PR DESCRIPTION
After reacting to a press f message, bot says
{server nickname}has paid their respects
now says 
{username} has paid their respects