### PR TITLE
Accept only common timezones to avoid confusion.

### DIFF
--- a/timezone/timezone.py
+++ b/timezone/timezone.py
@@ -1,7 +1,7 @@
 import discord
 import pytz
 from datetime import datetime
-from pytz import all_timezones
+from pytz import common_timezones
 from pytz import country_timezones
 from typing import Optional
 from redbot.core import Config, commands, checks
@@ -45,8 +45,11 @@ class Timezone(commands.Cog):
                         "<https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
                     )
                 else:
+                    tz = tz.title() if '/' in tz else tz.upper()
+                    if tz not in common_timezones:
+                        raise Exception(tz)
                     fmt = "**%H:%M** %d-%B-%Y **%Z (UTC %z)**"
-                    time = datetime.now(pytz.timezone(tz.title()))
+                    time = datetime.now(pytz.timezone(tz))
                     await ctx.send(time.strftime(fmt))
         except Exception as e:
             await ctx.send(f"**Error:** {str(e)} is an unsupported timezone.")
@@ -90,7 +93,7 @@ class Timezone(commands.Cog):
                 msg = f"Your current timezone is **{usertime}.**\n" f"The current time is: {time}"
                 await ctx.send(msg)
         else:
-            exist = True if tz.title() in all_timezones else False
+            exist = True if tz.title() in common_timezones else False
             if exist:
                 if "'" in tz:
                     tz = tz.replace("'", "")
@@ -112,7 +115,7 @@ class Timezone(commands.Cog):
             await ctx.send("That timezone is invalid.")
             return
         else:
-            exist = True if tz.title() in all_timezones else False
+            exist = True if tz.title() in common_timezones else False
             if exist:
                 if "'" in tz:
                     tz = tz.replace("'", "")


### PR DESCRIPTION
Because abbreviations like CST and AST aren't unique, they are not acceptable as timezones, whereas others without conflicts, like EST are acceptable. The pytz package provides a cleaned up list of useful timezones, pytz.common_timezones. This PR considers only those timezones to be acceptable and will report others as unsupported, thereby reducing user confusion as to why some timezone abbreviations work and others don't.

I found during testing that there are some timezones in the common_timezones list that the code currently does not accept, the deprecated 'US/Eastern', and similar. The reason they are rejected is the use of `tz.title()` to normalize the user's input. Using `tz.title().replace('Us/', 'US/')` everywhere `tz.title()` is used could make those timezones acceptable, but is beyond the scope of this PR. It would be fair to omit them because they are deprecated, but then you're taking a position against the pytz author's decision. It would be clearer to consistently support everything upstream supports in pytz.common_timezones.