### PR TITLE
[youtube] use params instead of query replacement

### DIFF
--- a/youtube/youtube.py
+++ b/youtube/youtube.py
@@ -13,10 +13,8 @@ class YouTube(commands.Cog):
 
     async def _youtube_results(self, query: str):
         try:
-            query = query.replace(" ", "+")
-            search_url = f"https://www.youtube.com/results?search_query={query}"
             headers = {"user-agent": "Red-cog/3.0"}
-            async with self.session.get(search_url, headers=headers) as r:
+            async with self.session.get("https://www.youtube.com/results", params={"search_query": query}, headers=headers) as r:
                 result = await r.text()
             yt_find = re.findall(r"{\"videoId\":\"(.{11})", result)
             url_list = []


### PR DESCRIPTION
Fixes `&` and other possible issues with search

Currently `odds&ends` search will return an search results for `https://www.youtube.com/results?search_query=odds&ends` which is basically search just for `odds`