### PR TITLE
[RNDStatus] Resolve potential heartbeat issues

### DIFF
--- a/rndstatus/rndstatus.py
+++ b/rndstatus/rndstatus.py
@@ -192,15 +192,9 @@ class RndStatus(commands.Cog):
             current = str(guild.me.activity.name)
         except AttributeError:
             current = None
-        try:
-            new = str(guild.me.activity.name)
-        except AttributeError:
-            new = None
-        if len(statuses) > 1:
-            while current == new:
-                new = rndchoice(statuses)
-        elif len(statuses) == 1:
-            new = statuses[0]
-        else:
-            new = None
-        return new
+        new_statuses = [s for s in statuses if s != current]
+        if len(new_statuses) > 1:
+            return rndchoice(new_statuses)
+        elif len(new_statuses) == 1:
+            return new_statuses[0]
+        return current


### PR DESCRIPTION
Certain edge cases, e.g. a two-tuple of duplicate statuses, would cause random_status (which never yields its context to the event loop) to either have an infinite or a long-running while loop.
This removes the while loop entirely.

[Heartattack logs](https://gist.github.com/zephyrkul/9a3257be2c17ba5d3270ecb7048bae2d) if you want them. This heartbeat log was generated by using `[p]rndstatus set test test` on current head; using the same list on this PR resulted in no issue.