### PR TITLE
[Tools] Sanitise invites in discord names

### DIFF
--- a/tools/tools.py
+++ b/tools/tools.py
@@ -9,6 +9,7 @@ import os
 import time
 from redbot.core import Config, checks, commands
 from redbot.core.utils import chat_formatting as cf
+from redbot.core.utils.common_filters import filter_invites
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS, close_menu
 from tabulate import tabulate
 from contextlib import suppress as sps
@@ -405,7 +406,10 @@ class Tools(commands.Cog):
         form = "{gid} :: {mems:0{zpadding}} :: {name}"
         all_forms = [
             form.format(
-                gid=g.id, mems=g.member_count, name=cf.escape(g.name), zpadding=max_zpadding
+                gid=g.id, 
+                mems=g.member_count, 
+                name=filter_invites(cf.escape(g.name)), 
+                zpadding=max_zpadding
             )
             for g in guilds
         ]


### PR DESCRIPTION
Not sure if you wanted this or not, just had an issue of some invites being in server names and thus was posting the ad in red 🏃‍♂️ 