### PR TITLE
[RSS] Fix invalid JSON information error

### DIFF
--- a/rss/info.json
+++ b/rss/info.json
@@ -6,5 +6,5 @@
     "tags": ["rss"],
     "permissions": ["embed_links"],
     "requirements": ["feedparser>=6.0.0", "bs4"],
-    "min_bot_version" : "3.4.0",
+    "min_bot_version" : "3.4.0"
 }


### PR DESCRIPTION
Minor fix. :catexplosion:

```py
[2020-09-18 20:16:18] [ERROR] red.downloader: Invalid JSON information file at path: /home/ubuntu/merlin/cogs/RepoManager/repos/aika/rss/info.json
Error: Expecting property name enclosed in double quotes: line 10 column 1 (char 284)
```