### PR TITLE
[timezone] Add `get_usertime` for outside calls

### DIFF
--- a/timezone/timezone.py
+++ b/timezone/timezone.py
@@ -3,7 +3,7 @@ import pytz
 from datetime import datetime
 from pytz import common_timezones
 from pytz import country_timezones
-from typing import Optional, Literal
+from typing import Optional, Literal, Tuple, Union
 from redbot.core import Config, commands, checks
 
 
@@ -20,6 +20,14 @@ class Timezone(commands.Cog):
         self.config = Config.get_conf(self, 278049241001, force_registration=True)
         default_user = {"usertime": None}
         self.config.register_user(**default_user)
+
+    async def get_usertime(self, user: discord.User):
+        tz = None
+        usertime = await self.config.user(user).usertime()
+        if usertime:
+            tz = pytz.timezone(usertime)
+
+        return usertime, tz
 
     @commands.guild_only()
     @commands.group()
@@ -86,14 +94,14 @@ class Timezone(commands.Cog):
             Usage: [p]time me Continent/City
         """
         if tz is None:
-            usertime = await self.config.user(ctx.message.author).usertime()
+            usertime, tz = await self.get_usertime(ctx.author)
             if not usertime:
                 await ctx.send(
                     f"You haven't set your timezone. Do `{ctx.prefix}time me Continent/City`: "
                     "see <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>"
                 )
             else:
-                time = datetime.now(pytz.timezone(usertime))
+                time = datetime.now(tz)
                 time = time.strftime("**%H:%M** %d-%B-%Y **%Z (UTC %z)**")
                 msg = f"Your current timezone is **{usertime}.**\n" f"The current time is: {time}"
                 await ctx.send(msg)
@@ -102,7 +110,7 @@ class Timezone(commands.Cog):
             if exist:
                 if "'" in tz:
                     tz = tz.replace("'", "")
-                await self.config.user(ctx.message.author).usertime.set(tz.title())
+                await self.config.user(ctx.author).usertime.set(tz.title())
                 await ctx.send(f"Successfully set your timezone to **{tz.title()}**.")
             else:
                 await ctx.send(
@@ -115,7 +123,7 @@ class Timezone(commands.Cog):
     async def set(self, ctx, user: discord.Member, *, tz=None):
         """Allows the mods to edit timezones."""
         if not user:
-            user = ctx.message.author
+            user = ctx.author
         if tz is None:
             await ctx.send("That timezone is invalid.")
             return
@@ -138,9 +146,9 @@ class Timezone(commands.Cog):
         if not user:
             await ctx.send("That isn't a user!")
         else:
-            usertime = await self.config.user(user).usertime()
+            usertime, tz = await self.get_usertime(user)
             if usertime:
-                time = datetime.now(pytz.timezone(usertime))
+                time = datetime.now(tz)
                 fmt = "**%H:%M** %d-%B-%Y **%Z (UTC %z)**"
                 time = time.strftime(fmt)
                 await ctx.send(
@@ -155,8 +163,8 @@ class Timezone(commands.Cog):
         if not user:
             return await ctx.send_help()
 
-        usertime = await self.config.user(ctx.message.author).usertime()
-        othertime = await self.config.user(user).usertime()
+        usertime, user_tz = await self.get_usertime(ctx.author)
+        othertime, other_tz = await self.get_usertime(user)
 
         if not usertime:
             return await ctx.send(
@@ -166,9 +174,9 @@ class Timezone(commands.Cog):
         if not othertime:
             return await ctx.send(f"That user's timezone isn't set yet.")
 
-        user_now = datetime.now(pytz.timezone(usertime))
+        user_now = datetime.now(user_tz)
         user_diff = user_now.utcoffset().total_seconds() / 60 / 60
-        other_now = datetime.now(pytz.timezone(othertime))
+        other_now = datetime.now(other_tz)
         other_diff = other_now.utcoffset().total_seconds() / 60 / 60
         time_diff = int(abs(user_diff - other_diff))
         fmt = "**%H:%M %Z (UTC %z)**"


### PR DESCRIPTION
Adds a function for accessing the usertime in config and pytz.timezone-ing it.

Also adjusts `ctx.message.author` to `ctx.author`