### PR TITLE
[RSS] Add feed update dispatch

### DIFF
--- a/rss/rss.py
+++ b/rss/rss.py
@@ -25,7 +25,7 @@ from .tag_type import INTERNAL_TAGS, VALID_IMAGES, TagType
 log = logging.getLogger("red.aikaterna.rss")
 
 
-__version__ = "1.1.19"
+__version__ = "1.1.21"
 
 
 class RSS(commands.Cog):

--- a/rss/rss.py
+++ b/rss/rss.py
@@ -872,6 +872,10 @@ class RSS(commands.Cog):
         # post oldest first
         feedparser_plus_objects.reverse()
 
+        # list of feedparser_plus_objects wrapped in MappingProxyType
+        # filled during the loop below
+        proxied_dicts = []
+
         for feedparser_plus_obj in feedparser_plus_objects:
             try:
                 curr_title = feedparser_plus_obj.title
@@ -915,13 +919,40 @@ class RSS(commands.Cog):
             #     See documentation of feedparser.FeedParserDict for more information.
             # force: bool
             #     True if the update was forced (through `[p]rss force`), False otherwise.
+            feedparser_dict_proxy = MappingProxyType(feedparser_plus_obj)
+            proxied_dicts.append(feedparser_dict_proxy)
             self.bot.dispatch(
                 "aikaternacogs_rss_message",
                 channel=channel,
                 feed_data=MappingProxyType(rss_feed),
-                feedparser_dict=MappingProxyType(feedparser_plus_obj),
+                feedparser_dict=feedparser_dict_proxy,
                 force=force,
             )
+
+        # This event can be used in 3rd-party using listeners.
+        # This may (and most likely will) get changes in the future
+        # so I suggest accepting **kwargs in the listeners using this event.
+        #
+        # channel: discord.TextChannel
+        #     The channel feed alerts went to.
+        # feed_data: Mapping[str, Any]
+        #     Read-only mapping with feed's data.
+        #     The available data depends on what this cog needs
+        #     and there most likely will be changes here in future.
+        #     Available keys include: `name`, `template`, `url`, `embed`, etc.
+        # feedparser_dicts: List[Mapping[str, Any]]
+        #     List of read-only mappings with parsed data
+        #     from each **new** entry in the feed.
+        #     See documentation of feedparser.FeedParserDict for more information.
+        # force: bool
+        #     True if the update was forced (through `[p]rss force`), False otherwise.
+        self.bot.dispatch(
+            "aikaternacogs_rss_feed_update",
+            channel=channel,
+            feed_data=MappingProxyType(rss_feed),
+            feedparser_dicts=proxied_dicts,
+            force=force,
+        )
 
     async def _get_current_feed_embed(
         self,


### PR DESCRIPTION
This PR adds an event called `on_aikaternacogs_rss_feed_update` that will be triggered for the whole feed update and will be called with all new entries that were found in this update.

I'm somewhat tempted to just remove `on_aikaternacogs_rss_message` because just iterating over the `feedparser_dicts` object from `on_aikaternacogs_rss_feed_update` in the listener function should have the same result, but it would cause breakage so I leave that up to you. I could also *document* it as "pending removal"/deprecated if you feel like that would be a good middle ground.

Also, let me know what version I should do the bump for and I can deal with it if you want me to.

~~*Pending testing*~~ Done.