### PR TITLE
[Tools] typo fix + sort perms

### DIFF
--- a/tools/tools.py
+++ b/tools/tools.py
@@ -476,7 +476,7 @@ class Tools(commands.Cog):
         perms = iter(ctx.channel.permissions_for(user))
         perms_we_have = ""
         perms_we_dont = ""
-        for x in perms:
+        for x in sorted(perms):
             if "True" in str(x):
                 perms_we_have += "+\t{0}\n".format(str(x).split("'")[1])
             else:
@@ -521,7 +521,7 @@ class Tools(commands.Cog):
             perms = iter(role.permissions)
             perms_we_have = ""
             perms_we_dont = ""
-            for x in perms:
+            for x in sorted(perms):
                 if "True" in str(x):
                     perms_we_have += "{0}\n".format(str(x).split("'")[1])
                 else:
@@ -543,8 +543,8 @@ class Tools(commands.Cog):
             em.add_field(name="ID", value=role.id)
             em.add_field(name="Color", value=role.color)
             em.add_field(name="Position", value=role.position)
-            em.add_field(name="Valid Permissons", value="{}".format(perms_we_have))
-            em.add_field(name="Invalid Permissons", value="{}".format(perms_we_dont))
+            em.add_field(name="Valid Permissions", value="{}".format(perms_we_have))
+            em.add_field(name="Invalid Permissions", value="{}".format(perms_we_dont))
             em.set_thumbnail(url=role.guild.icon_url)
         try:
             await loadingmsg.edit(embed=em)
@@ -558,7 +558,7 @@ class Tools(commands.Cog):
                 perms = iter(role.permissions)
                 perms_we_have2 = ""
                 perms_we_dont2 = ""
-                for x in perms:
+                for x in sorted(perms):
                     if "True" in str(x):
                         perms_we_have2 += "+{0}\n".format(str(x).split("'")[1])
                     else:


### PR DESCRIPTION
The main reason for proposing to sort permission values is because I assume it will probably be more helpful for mod/admins/owners who rely on this cog to lookup perms for target user/roles. For example, when perms are sorted, and if I have to lookup if a particular user or role has a said permission or not (let's say "administrator" or "manage_guild"), I can quickly visually lookup alphabetically from top (A) to bottom (Z) to see if those permissions are present in valid or invalid permissions which is relatively faster to read through and for lookup compared with non sorted perm values where one has to look through each of the perm values one by one and see if the perm value they're looking for matches.

Then again, it's totally up to you if you want to add this feature in the cog or not because I'm not quite sure if you like this or not. in any case, please let me know what do you think whether it will be 👍🏻 or 👎🏻