### PR TITLE
Changed display_name to name

### DIFF
--- a/chatchart/chatchart.py
+++ b/chatchart/chatchart.py
@@ -151,10 +151,10 @@ class Chatchart(commands.Cog):
 
         msg_data = {"total count": 0, "users": {}}
         for msg in history:
-            if len(msg.author.display_name) >= 20:
-                short_name = "{}...".format(msg.author.display_name[:20]).replace("$", "\\$")
+            if len(msg.author.name) >= 20:
+                short_name = "{}...".format(msg.author.name[:20]).replace("$", "\\$")
             else:
-                short_name = msg.author.display_name.replace("$", "\\$").replace("_", "\\_ ").replace("*", "\\*")
+                short_name = msg.author.name.replace("$", "\\$").replace("_", "\\_ ").replace("*", "\\*")
             whole_name = "{}#{}".format(short_name, msg.author.discriminator)
             if msg.author.bot:
                 pass


### PR DESCRIPTION
Changed `display_name` to `name` because discriminator with display_name doesnt seem to be a good thing.

![image](https://user-images.githubusercontent.com/77575049/108630354-57aa0080-748a-11eb-90ea-7e77af33ef66.png)
![image](https://user-images.githubusercontent.com/77575049/108630359-64c6ef80-748a-11eb-9dba-0483a13d2a81.png)
