### PR TITLE
[Dungeon] listener refactor

### DIFF
--- a/dungeon/dungeon.py
+++ b/dungeon/dungeon.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Literal, List
+from typing import Literal, List, Optional
 
 import discord
 import logging


### PR DESCRIPTION
Refactors the `on_member_join` listener and also adds guards for potential errors such as missing permissions or deleted roles/channels.

Also adds a bot owner check to the `[p]dungeon blacklist` command since servers shouldn't be able to modify the bot blacklist.

This PR has not been tested yet.