### PR TITLE
[ChatChart] Catch 404 on deleted channel

### DIFF
--- a/chatchart/chatchart.py
+++ b/chatchart/chatchart.py
@@ -279,6 +279,11 @@ class Chatchart(commands.Cog):
                     await loading_message.delete()
                 except discord.NotFound:
                     continue
+            except discord.NotFound:
+                try:
+                    await loading_message.delete()
+                except discord.NotFound:
+                    continue 
 
         msg_data = self.calculate_member_perc(global_history)
         # If no members are found.


### PR DESCRIPTION
If someone was to run the `[p]serverchart` command and then delete a channel, the bot would attempt to fetch messages from that now invalid channel and result in this error:

```python
Traceback (most recent call last):
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/main/red/cogs/CogManager/cogs/chatchart/chatchart.py", line 274, in serverchart
    history = await self.fetch_channel_history(channel, loading_message, messages)
  File "/home/main/red/cogs/CogManager/cogs/chatchart/chatchart.py", line 149, in fetch_channel_history
    async for msg in channel.history(limit=messages):
  File "/home/main/redenv/lib/python3.8/site-packages/discord/iterators.py", line 91, in __anext__
    msg = await self.next()
  File "/home/main/redenv/lib/python3.8/site-packages/discord/iterators.py", line 285, in next
    await self.fill_messages()
  File "/home/main/redenv/lib/python3.8/site-packages/discord/iterators.py", line 328, in fill_messages
    data = await self._retrieve_messages(self.retrieve)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/iterators.py", line 348, in _retrieve_messages_before_strategy
    data = await self.logs_from(self.channel.id, retrieve, before=before)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/http.py", line 250, in request
    raise NotFound(r, data)
discord.errors.NotFound: 404 Not Found (error code: 10003): Unknown Channel

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/main/redenv/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: NotFound: 404 Not Found (error code: 10003): Unknown Channel
```