### PR TITLE
[Away] Make [p]toggleaway and [p]awaytextonly guild only

### DIFF
--- a/away/away.py
+++ b/away/away.py
@@ -566,6 +566,7 @@ class Away(commands.Cog):
         await ctx.send(msg)
 
     @commands.command(name="toggleaway")
+    @commands.guild_only()
     @checks.admin_or_permissions(administrator=True)
     async def _ignore(self, ctx, member: discord.Member=None):
         """
@@ -600,6 +601,7 @@ class Away(commands.Cog):
         await ctx.send(message)
 
     @commands.command()
+    @commands.guild_only()
     @checks.admin_or_permissions(administrator=True)
     async def awaytextonly(self, ctx):
         """


### PR DESCRIPTION
These two commands access guild config settings and will error when someone tries to use them in DMs.