### PR TITLE
[Timezone] Output "same" when time zones match.

### DIFF
--- a/timezone/timezone.py
+++ b/timezone/timezone.py
@@ -199,11 +199,12 @@ class Timezone(commands.Cog):
         user_diff = user_now.utcoffset().total_seconds() / 60 / 60
         other_now = datetime.now(other_tz)
         other_diff = other_now.utcoffset().total_seconds() / 60 / 60
-        time_diff = str(abs(user_diff - other_diff)).rstrip(".0")
+        time_diff = abs(user_diff - other_diff)
+        time_diff_text = str(time_diff).rstrip(".0")
         fmt = "**%H:%M %Z (UTC %z)**"
         other_time = other_now.strftime(fmt)
         plural = "" if time_diff == 1 else "s"
-        time_amt = "the same time zone as you" if time_diff == 0 else f"{time_diff} hour{plural}"
+        time_amt = "the same time zone as you" if time_diff == 0 else f"{time_diff_text} hour{plural}"
         position = "ahead of" if user_diff < other_diff else "behind"
         position_text = "" if time_diff == 0 else f" {position} you"
 

--- a/timezone/timezone.py
+++ b/timezone/timezone.py
@@ -8,7 +8,7 @@ from redbot.core.utils.chat_formatting import pagify
 from redbot.core.utils.menus import close_menu, menu, DEFAULT_CONTROLS
 
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 
 class Timezone(commands.Cog):

--- a/timezone/timezone.py
+++ b/timezone/timezone.py
@@ -200,13 +200,13 @@ class Timezone(commands.Cog):
         other_now = datetime.now(other_tz)
         other_diff = other_now.utcoffset().total_seconds() / 60 / 60
         time_diff = abs(user_diff - other_diff)
-        time_diff_text = str(time_diff).rstrip(".0")
+        time_diff_text = f"{time_diff:g}"
         fmt = "**%H:%M %Z (UTC %z)**"
         other_time = other_now.strftime(fmt)
-        plural = "" if time_diff == 1 else "s"
-        time_amt = "the same time zone as you" if time_diff == 0 else f"{time_diff_text} hour{plural}"
+        plural = "" if time_diff_text == "1" else "s"
+        time_amt = "the same time zone as you" if time_diff_text == "0" else f"{time_diff_text} hour{plural}"
         position = "ahead of" if user_diff < other_diff else "behind"
-        position_text = "" if time_diff == 0 else f" {position} you"
+        position_text = "" if time_diff_text == "0" else f" {position} you"
 
         await ctx.send(f"{user.display_name}'s time is {other_time} which is {time_amt}{position_text}.")
 


### PR DESCRIPTION
When using `time compare`, when the time difference is 0, the intended "the same time zone as you" message is not being displayed. Instead, we are seeing "... `which is  hours behind you`". The misleading variable name `time_diff` (seems to suggest a number, but is actually a string) leads to faulty reasoning about its type, and therefore the three numeric comparisons that follow its definition in the `timezone compare` subcommand fail. This patch separates the formatted string `time_diff_text` from the numeric result to clear up the confusion.

The same bug prevents "1 hour behind" and "1 hour ahead" messages from ever being seen (for the same reason), and the fix addresses that issue, too.