### PR TITLE
[RSS] Fix message longer than 2000 in listtags

### DIFF
--- a/rss/rss.py
+++ b/rss/rss.py
@@ -1048,7 +1048,8 @@ class RSS(commands.Cog):
         msg += "\n\n\t[X] = html | [\\] = dictionary | [-] = list | [ ] = plain text"
         msg += "\n\t[*] = specially-generated tag, may not be present in every post"
 
-        await ctx.send(box(msg, lang="ini"))
+        for msg_part in pagify(msg, delims=["\n\t", "\n\n"]):
+            await ctx.send(box(msg_part, lang="ini"))
 
     @checks.is_owner()
     @rss.group(name="parse")


### PR DESCRIPTION
Fixing an issue where `[p]rss listtags` would raise an error in case there's too many tags...

Yup, that exist, I'm not kidding 😛
Feed used that is over +2000 characters: https://fitgirl-repacks.site/feed

Changes have been tested and work as intended, can be committed in peace.