### PR TITLE
[TrickOrTreat] Use `escape_markdown` for names in `[p]cboard`

### DIFF
--- a/trickortreat/trickortreat.py
+++ b/trickortreat/trickortreat.py
@@ -275,10 +275,11 @@ class TrickOrTreat(commands.Cog):
                     user_obj = await self.bot.fetch_user(account[0])
             except AttributeError:
                 user_obj = await self.bot.fetch_user(account[0])
-
-            user_name = f"{user_obj.name}#{user_obj.discriminator}"
+            
+            _user_name = discord.utils.escape_markdown(user_obj.name)
+            user_name = f"{_user_name}#{user_obj.discriminator}"
             if len(user_name) > 28:
-                user_name = discord.utils.escape_markdown(f"{user_obj.name[:19]}...#{user_obj.discriminator}")
+                user_name = f"{_user_name[:19]}...#{user_obj.discriminator}"
             user_idx = pos + 1
             if user_obj == ctx.author:
                 temp_msg += (

--- a/trickortreat/trickortreat.py
+++ b/trickortreat/trickortreat.py
@@ -278,7 +278,7 @@ class TrickOrTreat(commands.Cog):
 
             user_name = f"{user_obj.name}#{user_obj.discriminator}"
             if len(user_name) > 28:
-                user_name = f"{user_obj.name[:19]}...#{user_obj.discriminator}"
+                user_name = discord.utils.escape_markdown(f"{user_obj.name[:19]}...#{user_obj.discriminator}")
             user_idx = pos + 1
             if user_obj == ctx.author:
                 temp_msg += (


### PR DESCRIPTION
Use `escape_markdown` for names in `[p]cboard` so that syntax highlighting doesn't become obfuscated such as in the image below:

![image](https://user-images.githubusercontent.com/67752638/194710142-41555688-c6bd-4303-9582-be456ad908f3.png)
