### PR TITLE
Fix for double posting issues

### DIFF
--- a/rss/rss.py
+++ b/rss/rss.py
@@ -1405,10 +1405,6 @@ class RSS(commands.Cog):
                     log.debug(f"New entry found via time and link validation for feed {name} on cid {channel.id}")
                     feedparser_plus_obj = await self._add_to_feedparser_object(entry, url)
                     feedparser_plus_objects.append(feedparser_plus_obj)
-                if (last_title == "" and entry_title == "") and (last_link != entry_link) and (last_time < entry_time):
-                    log.debug(f"New entry found via time validation for feed {name} on cid {channel.id} - no title")
-                    feedparser_plus_obj = await self._add_to_feedparser_object(entry, url)
-                    feedparser_plus_objects.append(feedparser_plus_obj)
 
             # this is a post that has no time information attached to it and we can only
             # verify that the title and link did not match the previously posted entry


### PR DESCRIPTION
This if statement is such that if there is no title in this feed it meets the criteria for this If and the one above and thus gets placed in the queue twice and double posted. Ive seen this in Mastodon feeds for example.


                if (last_title == "" and entry_title == "") and (last_link != entry_link) and (last_time < entry_time):
                    log.debug(f"New entry found via time validation for feed {name} on cid {channel.id} - no title")
                    feedparser_plus_obj = await self._add_to_feedparser_object(entry, url)
                    feedparser_plus_objects.append(feedparser_plus_obj)