### PR TITLE
Limit the warning suppression to the rss cog

### DIFF
--- a/rss/rss.py
+++ b/rss/rss.py
@@ -43,7 +43,7 @@ warnings.filterwarnings(
         " `updated_parsed` to `published_parsed` if `updated_parsed` doesn't exist"
     )
 )
-warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
+warnings.filterwarnings("ignore", module="rss", category=MarkupResemblesLocatorWarning)
 
 
 class RSS(commands.Cog):


### PR DESCRIPTION
Needs testing to verify that the latest version of beautifulsoup in fact fixes the place it reports at and shows `rss` correctly.