### PR TITLE
rss: Reliably validate images.

### DIFF
--- a/rss/info.json
+++ b/rss/info.json
@@ -5,6 +5,6 @@
     "description": "Read RSS feeds.",
     "tags": ["rss"],
     "permissions": ["embed_links"],
-    "requirements": ["bs4", "feedparser>=6.0.0", "webcolors==1.3"],
+    "requirements": ["bs4", "feedparser>=6.0.0", "webcolors==1.3", "filetype"],
     "end_user_data_statement": "This cog does not persistently store data or metadata about users."
 }

--- a/rss/rss.py
+++ b/rss/rss.py
@@ -5,7 +5,7 @@ import copy
 import datetime
 import discord
 import feedparser
-import imghdr
+import filetype
 import io
 import logging
 import re
@@ -602,10 +602,12 @@ class RSS(commands.Cog):
             timeout = aiohttp.ClientTimeout(total=20)
             async with aiohttp.ClientSession(headers=self._headers, timeout=timeout) as session:
                 async with session.get(url) as resp:
-                    image = await resp.read()
+                    image = await resp.content.read(261)
             img = io.BytesIO(image)
-            image_test = imghdr.what(img)
-            return image_test
+            file_type = filetype.guess(img)
+            if not file_type:
+                return None
+            return file_type.extension
         except aiohttp.client_exceptions.InvalidURL:
             return None
         except asyncio.exceptions.TimeoutError:


### PR DESCRIPTION
- no longer fails to recognize some JPEG images set in the embed with `[p]rss embed image` or `[p]rss embed thumbnail`
- replaces the deprecated and broken `imghdr.what()` with `filetype.guess()`
- `filetype` documentation says only 261 bytes are needed, so only that many bytes are now read from stream