### PR TITLE
[Tools] `Guild.bans` is now an async generator

### DIFF
--- a/tools/tools.py
+++ b/tools/tools.py
@@ -150,7 +150,7 @@ class Tools(commands.Cog):
     async def banlist(self, ctx):
         """Displays the server's banlist."""
         try:
-            banlist = await ctx.guild.bans()
+            banlist = [bans async for bans in ctx.guild.bans()]
         except discord.errors.Forbidden:
             await ctx.send("I do not have the `Ban Members` permission.")
             return


### PR DESCRIPTION
basically fixes this error

```py
Traceback (most recent call last):
  File "/MELON/lib/python3.11/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.local/share/Red-DiscordBot/data/MELON/cogs/CogManager/cogs/tools/tools.py", line 153, in banlist
    banlist = await ctx.guild.bans()
              ^^^^^^^^^^^^^^^^^^^^^^
TypeError: object async_generator can't be used in 'await' expression

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/MELON/lib/python3.11/site-packages/discord/ext/commands/bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "/MELON/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1023, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/MELON/lib/python3.11/site-packages/discord/ext/commands/core.py", line 238, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: object async_generator can't be used in 'await' expression
```