### PR TITLE
[RSS] Remove unnecessary check for embed permissions

### DIFF
--- a/rss/rss.py
+++ b/rss/rss.py
@@ -1488,14 +1488,13 @@ class RSS(commands.Cog):
 
             embed_toggle = rss_feed["embed"]
             red_embed_settings = await self.bot.embed_requested(channel)
-            embed_permissions = channel.permissions_for(channel.guild.me).embed_links
 
             rss_limit = rss_feed.get("limit", 0)
             if rss_limit > 0:
                 # rss_limit needs + 8 characters for pagify counting codeblock characters
                 message = list(pagify(message, delims=["\n", " "], priority=True, page_length=(rss_limit + 8)))[0]
 
-            if embed_toggle and red_embed_settings and embed_permissions:
+            if embed_toggle and red_embed_settings:
                 await self._get_current_feed_embed(channel, rss_feed, feedparser_plus_obj, message)
             else:
                 for page in pagify(message, delims=["\n"]):


### PR DESCRIPTION
This is now checked by default by `bot.embed_requested()` so this can be simplified, see:
- [the documentation of `check_permissions` in `bot.embed_requested()`](https://docs.discord.red/en/stable/framework_bot.html#redbot.core.bot.Red.embed_requested)
- [the notice about the default value of `check_permissions` changing to `True`](https://docs.discord.red/en/stable/incompatible_changes/3.5.html#red-embed-requested-s-parameters-and-their-default-values-have-changed)
