### PR TITLE
Fix name errors in rss and icyparser cogs

### DIFF
--- a/icyparser/icyparser.py
+++ b/icyparser/icyparser.py
@@ -1,3 +1,4 @@
+import asyncio
 import aiohttp
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.http_parser import HttpResponseParserPy
@@ -287,7 +288,7 @@ class IcyParser(commands.Cog):
 
         except Exception:
             log.error(
-                f"Icyparser's _metadata_read encountered an error while trying to read a stream at {url}", exc_info=True
+                f"Icyparser's _metadata_read encountered an error while trying to read a stream at {resp.url}", exc_info=True
             )
         return None
 

--- a/rss/rss.py
+++ b/rss/rss.py
@@ -1659,8 +1659,8 @@ class RSS(commands.Cog):
                         await self.get_current_feed(
                             queue_item[2].channel, queue_item[2].feed_name, queue_item[2].feed_data
                         )
-                    except aiohttp.client_exceptions.InvalidURL:
-                        log.debug(f"Feed at {url} is bad or took too long to respond.")
+                    except aiohttp.client_exceptions.InvalidURL as e:
+                        log.debug(f"Feed at {e.url} is bad or took too long to respond.")
                         continue
 
                     if self._post_queue_size < 300:

--- a/rss/rss_feed.py
+++ b/rss/rss_feed.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 class RssFeed():
     """RSS feed object"""
 


### PR DESCRIPTION
I was actually trying to locate the `NameError` for #315 but it turns out that it has already been fixed by c6bd321d742516aed44cdb3b29774aa4f56e9f12 so I'm instead providing you with fixes for all name errors that were detected by the ruff linter (`ruff . --select F821` command).