### PR TITLE
[RSS] Ensure that the feed update event is only sent when message was sent

### DIFF
--- a/rss/rss.py
+++ b/rss/rss.py
@@ -33,7 +33,7 @@ IPV6_RE = re.compile("([a-f0-9:]+:+)+[a-f0-9]+")
 GuildMessageable = Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread]
 
 
-__version__ = "2.1.7"
+__version__ = "2.1.8"
 
 warnings.filterwarnings(
     "ignore",

--- a/rss/rss.py
+++ b/rss/rss.py
@@ -1539,6 +1539,7 @@ class RSS(commands.Cog):
         # filled during the loop below
         proxied_dicts = []
 
+        sent_message = False
         for feedparser_plus_obj in feedparser_plus_objects:
             try:
                 curr_title = feedparser_plus_obj.title
@@ -1584,6 +1585,7 @@ class RSS(commands.Cog):
             else:
                 for page in pagify(message, delims=["\n"]):
                     await channel.send(page)
+            sent_message = True
 
             # This event can be used in 3rd-party using listeners.
             # This may (and most likely will) get changes in the future
@@ -1610,6 +1612,9 @@ class RSS(commands.Cog):
                 feedparser_dict=feedparser_dict_proxy,
                 force=force,
             )
+
+        if not sent_message:
+            return
 
         # This event can be used in 3rd-party using listeners.
         # This may (and most likely will) get changes in the future


### PR DESCRIPTION
I notice that sometimes my `rssnotifier` cog (which uses the feed update event) sends a mention message when there's actually no message sent from the RSS cog. Presumably, it's because sometimes the loop may not send any message due to running into `continue` on each iteration.
I have no good way of validating this assumption but this should be a harmless change.